### PR TITLE
Prevent description editing message to be displayed when loading a team

### DIFF
--- a/src/components/TeamNavbar/index.js
+++ b/src/components/TeamNavbar/index.js
@@ -61,6 +61,17 @@ class TeamNavbar extends Component {
 
   handleDescriptionUpdate = (data: { description: string }) => this.props.onDescriptionUpdate(data);
 
+  descriptionText = () => {
+    if(this.teamIsLoaded()) {
+      const { description } = this.props.team;
+      return description ? description : 'Click here to edit description';
+    } else {
+      return '';
+    }
+  };
+
+  teamIsLoaded = () => this.props.team.id;
+
   render() {
     const { team } = this.props;
     const { editingDescription } = this.state;
@@ -81,7 +92,7 @@ class TeamNavbar extends Component {
                 className={css(styles.descriptionButton)}
                 onClick={() => this.setState({ editingDescription: true })}
               >
-                {team.description ? team.description : 'Click here to edit description'}
+                {this.descriptionText()}
               </button>
           }
         </div>


### PR DESCRIPTION
Previously, when you would go to a team's page, no title would display and a description of 'Click here to edit description' would be shown while the team's information is being fetched. This change checks that the team is fetched before displaying that default description. While the team is being fetched it will not display any description.