### PR TITLE
Ping Route Links to New Tab

### DIFF
--- a/src/components/ReservationTable/index.js
+++ b/src/components/ReservationTable/index.js
@@ -235,6 +235,7 @@ class ReservationCell extends Component {
           {reserveButton}
           {releaseButton}
           <a
+            target={'_blank'}
             href={`https://${environment.name}-${
               application.name
             }.${environmentType}.covermymeds.com/${application.ping}`}


### PR DESCRIPTION
This change makes it so when you click the `Info` button, it links the ping route in another tab. I think this makes more sense than opening it in the current tab because typically a person wants to check the ping route to see which branch it is on so they know if they can reserve it.

Links to #15 